### PR TITLE
dockerisation

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,13 @@
+# Set MODE to one of the following: watch | development | production | test
+# MODE=watch
+
+ALLOWED_HOSTS=web
+POSTGRES_HOST=database
+POSTGRES_PORT=5432
+POSTGRES_DB=db
+POSTGRES_USER=admin
+POSTGRES_PASSWORD=pauper
+
+GA_ID=UA-000000000-0
+SECRET_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+ADMIN_EMAIL=admin@hostname.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,98 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+.mypy_cache/
+.pytest_cache/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+# lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3
+# LABEL maintainer="timvanmourik@gmail.com" <-- replace
+
+ENV PYTHONUNBUFFERED 1
+RUN mkdir /code /code/requirements
+WORKDIR /code
+
+# Install Python dependencies
+COPY requirements.txt /code/
+COPY requirements/base.txt /code/requirements/
+RUN pip install -r requirements.txt
+
+EXPOSE 8000

--- a/bin/docker-command.bash
+++ b/bin/docker-command.bash
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# run server
+cd src
+python manage.py runserver 0.0.0.0:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3'
+
+services:
+  database:
+    restart: unless-stopped
+    image: postgres:10.1-alpine
+    volumes:
+      # This saves the database to a persistent volume:
+      - postgres:/var/lib/postgresql/data
+      # You could also save it locally to the `database` directory...
+      # - ./database:/var/lib/postgresql/data
+      # if ever we want to initialise the database
+      # - ./demo.sql:/docker-entrypoint-initdb.d/init.sql
+    ports:
+      #TODO only works without quotes here, not sure why
+      - 5432   # database port
+
+  web:
+    env_file:
+      - ./.env.sample # <-- replace this with .env in production
+    build: .
+    volumes:
+      - .:/code
+    command: ./bin/docker-command.bash
+    ports:
+      - "8000:8000"
+      - "35729:35729"   # django live reload server
+    depends_on:
+      - database
+
+volumes:
+  postgres:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+-r requirements/base.txt

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,0 +1,12 @@
+Django==2.1.10
+django-appconf==1.0.3
+django-compressor==2.3
+django-libsass==0.7
+libsass==0.19.3
+matplotlib==3.1.1
+pandas==0.25.1
+plotly==4.1.1
+psycopg2-binary==2.8.2
+pillow==6.2.0
+rcssmin==1.0.6
+rjsmin==1.1.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,0 +1,1 @@
+-r base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,0 +1,6 @@
+-r base.txt
+django-coverage-plugin
+pytest
+pytest-cov
+pytest-django
+responses


### PR DESCRIPTION
This PR adds code to the repo to spin up the site with Docker. After installing Docker, you can run your site with: `docker-compose up`.

In the `docker-compose.yml` file, you see that there are two 'services', a database and the website itself. This reduces the need for a conda env file because conda (like Docker) is an envoironment manager. Only Docker works beyond Python. So I added a `requirements.txt` file from which dependencies are installed in the `Dockerfile`.